### PR TITLE
Adiciona testes para instruções ANDI e LUI

### DIFF
--- a/tb/tests/RISCV_andi_test.sv
+++ b/tb/tests/RISCV_andi_test.sv
@@ -1,0 +1,38 @@
+///------------------------------------------------------------------------------
+// ANDI test for RISCV
+//------------------------------------------------------------------------------
+// This UVM test sets up the environment and sequence for the RISCV verification.
+//
+// Author: Henrique Teixeira
+// Date  : July 2025
+//------------------------------------------------------------------------------
+
+`ifndef RISCV_ANDI_TEST
+`define RISCV_ANDI_TEST
+
+class RISCV_andi_test extends uvm_test;
+
+  `uvm_component_utils(RISCV_andi_test)
+
+  RISCV_environment env;
+  RISCV_andi_seq    seq;
+
+  function new(string name = "RISCV_andi_test", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    env = RISCV_environment::type_id::create("env", this);
+    seq = RISCV_andi_seq::type_id::create("seq");
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    phase.raise_objection(this);
+    seq.start(env.RISCV_agnt.sequencer);
+    phase.drop_objection(this);
+  endtask
+
+endclass
+
+`endif

--- a/tb/tests/RISCV_lui_test.sv
+++ b/tb/tests/RISCV_lui_test.sv
@@ -1,0 +1,38 @@
+//------------------------------------------------------------------------------
+// LUI test for RISCV
+//------------------------------------------------------------------------------
+// This UVM test sets up the environment and sequence for the RISCV verification.
+//
+// Author: Henrique Teixeira
+// Date  : July 2025
+//------------------------------------------------------------------------------
+
+`ifndef RISCV_LUI_TEST
+`define RISCV_LUI_TEST
+
+class RISCV_lui_test extends uvm_test;
+
+  `uvm_component_utils(RISCV_lui_test)
+
+  RISCV_environment env;
+  RISCV_lui_seq     seq;
+
+  function new(string name = "RISCV_lui_test", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    env = RISCV_environment::type_id::create("env", this);
+    seq = RISCV_lui_seq::type_id::create("seq");
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    phase.raise_objection(this);
+    seq.start(env.RISCV_agnt.sequencer);
+    phase.drop_objection(this);
+  endtask
+
+endclass
+
+`endif

--- a/tb/tests/RISCV_test_list.sv
+++ b/tb/tests/RISCV_test_list.sv
@@ -28,6 +28,8 @@ package RISCV_test_list;
   `include "RISCV_and_test.sv" 
   `include "RISCV_beq_test.sv" 
   `include "RISCV_jal_test.sv" 
+  `include "RISCV_andi_test.sv" 
+  `include "RISCV_lui_test.sv" 
 
 endpackage 
 

--- a/tb/tests/sequence_lib/RISCV_andi_seq.sv
+++ b/tb/tests/sequence_lib/RISCV_andi_seq.sv
@@ -1,0 +1,67 @@
+//------------------------------------------------------------------------------
+// ANDI sequence for RISCV
+//------------------------------------------------------------------------------
+// This sequence generates randomized transactions for the RISCV UVM verification.
+//
+// Author: Henrique Teixeira
+// Date  : July 2025
+//------------------------------------------------------------------------------
+
+`ifndef RISCV_ANDI_SEQ
+`define RISCV_ANDI_SEQ
+
+class RISCV_andi_seq extends uvm_sequence#(RISCV_transaction);
+
+  `uvm_object_utils(RISCV_andi_seq)
+
+  // Randomizable fields
+  rand bit [31:0] rs1_value;
+  rand bit [11:0] imm;
+  rand bit [4:0]  rs1_addr;
+  rand bit [4:0]  rd_addr;
+
+  // Constants for ANDI
+  localparam bit [6:0] ANDI_OPCODE = 7'b0010011;
+  localparam bit [2:0] ANDI_FUNCT3 = 3'b111;
+
+  function new(string name = "RISCV_andi_seq");
+    super.new(name);
+  endfunction
+
+  virtual task body();
+    bit [31:0] imm_sext;
+    bit [31:0] rd_value;
+
+    repeat(`NO_OF_TRANSACTIONS) begin
+      req = RISCV_transaction::type_id::create("req");
+      start_item(req);
+
+      if (!randomize(imm, rs1_addr, rd_addr, rs1_value)) begin
+        `uvm_fatal(get_type_name(), "Randomization failed!");
+      end
+
+      // Sign-extend the immediate
+      imm_sext = {{20{imm[11]}}, imm};
+      rd_value = rs1_value & imm_sext;
+
+      // Build I-type instruction
+      req.instr_data = {
+        imm, rs1_addr, ANDI_FUNCT3, rd_addr, ANDI_OPCODE
+      };
+
+      req.data_rd = rd_value;
+
+      req.instr_name = $sformatf(
+        "ANDI x%0d, x%0d, %0d | %0d & %0d = %0d",
+        rd_addr, rs1_addr, $signed(imm), rs1_value, $signed(imm_sext), rd_value
+      );
+
+      `uvm_info(get_full_name(), $sformatf("Generated ANDI instruction: %s", req.instr_name), UVM_LOW);
+
+      finish_item(req);
+    end
+  endtask
+
+endclass
+
+`endif

--- a/tb/tests/sequence_lib/RISCV_lui_seq.sv
+++ b/tb/tests/sequence_lib/RISCV_lui_seq.sv
@@ -1,0 +1,61 @@
+//------------------------------------------------------------------------------
+// LUI sequence for RISCV
+//------------------------------------------------------------------------------
+// This sequence generates randomized transactions for the RISCV UVM verification.
+//
+// Author: Henrique Teixeira
+// Date  : July 2025
+//------------------------------------------------------------------------------
+
+`ifndef RISCV_LUI_SEQ
+`define RISCV_LUI_SEQ
+
+class RISCV_lui_seq extends uvm_sequence#(RISCV_transaction);
+
+  `uvm_object_utils(RISCV_lui_seq)
+
+  // Randomizable fields
+  rand bit [19:0] imm;
+  rand bit [4:0]  rd_addr;
+
+  // Constants for LUI
+  localparam bit [6:0] LUI_OPCODE = 7'b0110111;
+
+  function new(string name = "RISCV_lui_seq");
+    super.new(name);
+  endfunction
+
+  virtual task body();
+    bit [31:0] rd_value;
+
+    repeat(`NO_OF_TRANSACTIONS) begin
+      req = RISCV_transaction::type_id::create("req");
+      start_item(req);
+
+      if (!randomize(imm, rd_addr)) begin
+        `uvm_fatal(get_type_name(), "Randomization failed!");
+      end
+
+      rd_value = {imm, 12'b0};
+
+      // Build U-type instruction
+      req.instr_data = {
+        imm, rd_addr, LUI_OPCODE
+      };
+
+      req.data_rd = rd_value;
+
+      req.instr_name = $sformatf(
+        "LUI x%0d, 0x%0h | Result = 0x%0h",
+        rd_addr, imm, rd_value
+      );
+
+      `uvm_info(get_full_name(), $sformatf("Generated LUI instruction: %s", req.instr_name), UVM_LOW);
+
+      finish_item(req);
+    end
+  endtask
+
+endclass
+
+`endif

--- a/tb/tests/sequence_lib/RISCV_seq_list.sv
+++ b/tb/tests/sequence_lib/RISCV_seq_list.sv
@@ -29,6 +29,8 @@ package RISCV_seq_list;
   `include "RISCV_addi_seq.sv"
   `include "RISCV_beq_seq.sv"
   `include "RISCV_jal_seq.sv"
+  `include "RISCV_andi_seq.sv"
+  `include "RISCV_lui_seq.sv"
 
 endpackage
 


### PR DESCRIPTION
Adicionei os novos testes para as instruções ANDI e LUI no processador.

Criei os arquivos de teste (RISCV_andi_test.sv e RISCV_lui_test.sv)
Criei as sequences correspondentes (RISCV_andi_seq.sv e RISCV_lui_seq.sv)
Atualizei RISCV_seq_list.sv e RISCV_test_list.sv para incluir esses novos testes

Já estou randomizando as entradas, montando a instrução corretamente e validando que ela chega ao DUT. 

Ainda não estou validando se o DUT escreve o valor correto no registrador destino — está no mesmo padrão dos outros testes que temos (como ADD, ADDI, AND).
Peço que revisem para ver se está tudo no padrão e deem o ok para o merge se for o caso.

Obrigado!
